### PR TITLE
Threejstest

### DIFF
--- a/examples/simple_diffusion/ioperformance.py
+++ b/examples/simple_diffusion/ioperformance.py
@@ -78,49 +78,79 @@ if __name__ == '__main__':
         we can measure the peroformace as we become IO/Memory bound. """
     
     model = simple_diffusion2()
-    print str(4*1620*500/1.048e6) + " MB"
+    print "Output data set size:", str(4*1620*500/1.048e6) + " MB"
     model.timespan(numpy.linspace(0,1,500))
 
     tic = time.time()
     result = urdme(model,report_level=0)
     print "\t pyurdme took "+str(time.time()-tic)+" s."
     tic = time.time()
-    U = result["U"]
-    Asum=numpy.sum(U[:,::2],axis=1)
-    print "\t and accessing the data and aggregating one species took "+str(time.time()-tic)+" s."
-    #print Asum
+    A = result.getSpecies("A")
 
-    print str(4*1620*5000/1.024e6) + " MB"
+    #U = result["U"]
+    Asum=numpy.sum(A,axis=1)
+    print "\t and accessing the data and aggregating one species took "+str(time.time()-tic)+" s."
+    # Get A at a selceted time point
+    tic  = time.time()
+    A = result.getSpecies("A",[300])
+    #print numpy.sum(A,axis=1)
+    print "\t Selecting a singe timepoint took "+str(time.time()-tic)+" s."
+
+
+    print "Output data set size:",str(4*1620*5000/1.024e6) + " MB"
     model.timespan(numpy.linspace(0,1,5000))
     tic = time.time()
     result = urdme(model,report_level=0)
     print "\t pyurdme took "+str(time.time()-tic)+" s."
     tic = time.time()
-    U = result["U"]
-    Asum=numpy.sum(U[:,::2],axis=1)
-    #print Asum
+    # U = result["U"]
+    A = result.getSpecies("A")
 
-    print "\t and accessing the data and aggregating one species took "+str(time.time()-tic)+" s."
+    Asum=numpy.sum(A,axis=1)
 
-    print str(4*1620*50000/1.024e6) + " MB"
+    print "\t and accessing all timepoints for one species took "+str(time.time()-tic)+" s."
+    # Get A at a selceted time point
+    tic  = time.time()
+    A = result.getSpecies("A",[4000])
+    #print numpy.sum(A,axis=1)
+    print "\t Selecting a singe timepoint took "+str(time.time()-tic)+" s."
+
+
+
+    print "Output data set size:", str(4*1620*50000/1.024e6) + " MB"
     model.timespan(numpy.linspace(0,1,50000))
     tic = time.time()
     result = urdme(model,report_level=0)
     print "\t pyurdme took "+str(time.time()-tic)+" s."
     tic = time.time()
-    U = result["U"]
-    Asum=numpy.sum(U[:,::2],axis=1)
-    print "\t and accessing the data and aggregating one species took "+str(time.time()-tic)+" s."
+    A = result.getSpecies("A")
+    
+    Asum=numpy.sum(A,axis=1)
+    print "\t and accessing all timepoints for one species took "+str(time.time()-tic)+" s."
+    # Get A at a seleceted time point
+    tic  = time.time()
+    A = result.getSpecies("A",[25000])
+    #print numpy.sum(A,axis=1)
+    print "\t Selecting a singe timepoint took "+str(time.time()-tic)+" s."
 
-    print str(4*1620*500000/1.024e6) + " MB"
+
+    print "Output data set size:", str(4*1620*500000/1.024e6) + " MB"
     model.timespan(numpy.linspace(0,1,500000))
     tic = time.time()
     result = urdme(model,report_level=0)
     print "\t pyurdme took "+str(time.time()-tic)+" s."
     tic = time.time()
-    U = result["U"]
-    Asum=numpy.sum(U[:,::2],axis=1)
-    print "\t and accessing the data and aggregating one species took "+str(time.time()-tic)+" s."
+    #U = result["U"]
+    A = result.getSpecies("A")
+    Asum=numpy.sum(A,axis=1)
+    print "\t and accessing all timepoints for one species took "+str(time.time()-tic)+" s."
+
+    # Get A at a selceted time point
+    tic  = time.time()
+    A = result.getSpecies("A",[100000])
+    #print numpy.sum(A,axis=1)
+    print "\t Selecting a singe timepoint took "+str(time.time()-tic)+" s."
+
 
 
 

--- a/pyurdme/urdme/src/nsm/nsmcore.c
+++ b/pyurdme/urdme/src/nsm/nsmcore.c
@@ -195,7 +195,6 @@ The output is a matrix U (Ndofs X length(tspan)).
     printf("Failed to write tspan vector HDF5 file.");
     exit(-1);
   }
-
     
   hid_t trajectory_dataset, datatype,trajectory_dataspace, file_dataspace;
   datatype = H5Tcopy(H5T_NATIVE_INT);
@@ -297,7 +296,14 @@ The output is a matrix U (Ndofs X length(tspan)).
           
           
           /* Write to the buffer */
-          memcpy(&buffer[Ndofs*num_columns_since_flush],xx,Ndofs*sizeof(int));
+          for (i=0; i<Ncells;i++){
+              for (int s=0; s<Mspecies; s++){
+                  buffer[Ndofs*num_columns_since_flush+s*Ncells+i] = xx[i*Mspecies+s];
+              }
+          }
+          
+          //memcpy(&buffer[Ndofs*num_columns_since_flush],xx,Ndofs*sizeof(int));
+          
           num_columns_since_flush++;
         
           if (num_columns_since_flush == num_columns){
@@ -307,7 +313,7 @@ The output is a matrix U (Ndofs X length(tspan)).
                   printf("Failed to flush buffer to file.");
                   exit(-1);
               }
-             // printf("Flushed buffer, wrote %i columns\n",num_columns_since_flush);
+
               num_columns_since_flush = 0;
               chunk_indx++;
               total_columns_written += num_columns;


### PR DESCRIPTION
getSpecies can slice efficiently in the hdf5 dataset U. Load time and memory usage of say one species at a given timepoint dramatically improved. Internally, the layout of the data i U have changed again. For a given timepoint, the dofs are U[i,:], where 0...Ncells-1 is species A, Ncells...2Ncells-1 speceis B etc. 

Postprocessing routinges may need to change to accomodate for this (unless using getSpecies). 

Now there are two routes to accessing data 
1.) getSpecies - partial IO, never store U in result object. Memory lean. 
2.) U = result["U"], same behavior as before. U added to result object. 
